### PR TITLE
headless script needs fixed to find path to JARs, so it can launch

### DIFF
--- a/dist/dist_include/behaviorsearch_headless.sh
+++ b/dist/dist_include/behaviorsearch_headless.sh
@@ -8,7 +8,7 @@ BSEARCH_DIR="`dirname "$0"`" # the copious quoting is for handling paths with sp
 cd "$BSEARCH_DIR"
 BSEARCH_DIR="`pwd`"  #in case it's a relative path, like "."
 cd ..
-LIBRARY_DIR="`pwd`"  #in case it's a relative path, like "."
+LIBRARY_DIR="`pwd`/lib/app"  #in case it's a relative path, like "."
 JARS=""
 for f in `ls -1 "$LIBRARY_DIR" | grep "jar"`; do
   JARS="$LIBRARY_DIR/$f:$JARS"


### PR DESCRIPTION
I'm guessing this has been broken for a long while, but a user who was trying to run BehaviorSearch headless on Linux (on AWS) just reported it to me. 

Also, I presume the Windows .BAT and Mac .COMMAND headless scripts will both need similar updates to include "/app/lib" in the LIBRARY_PATH environment variable, but I don't have time to figure that out those fixes right now.

(Running headless on Linux is probably the most important use case, since most HPC/clusters use Linux.)